### PR TITLE
Expose get_explanations (needed for Thonny plugin)

### DIFF
--- a/edulint/__init__.py
+++ b/edulint/__init__.py
@@ -2,8 +2,9 @@ from .linters import Linter
 from .config.config import Config
 from .linting.problem import Problem
 from .linting.linting import lint_one, lint_many
+from .explanations import get_explanations
 
-__all__ = ["Linter", "Config", "Problem", "lint_one", "lint_many"]
+__all__ = ["Linter", "Config", "Problem", "lint_one", "lint_many", "get_explanations"]
 
-__version__ = "2.6.4"
+__version__ = "2.6.5"
 __version_info__ = tuple(map(int, __version__.split(".")))


### PR DESCRIPTION
This PR exposes function [`get_explanations`](https://github.com/GiraffeReversed/edulint/blob/8f4568e06209ec146cd8a507a8f67d17922819f6/edulint/explanations.py#L10), so that it can be called during module import.
This functionality is needed for IDE plugins, e.g. [thonny-edulint](https://github.com/GiraffeReversed/thonny-edulint).