### PR TITLE
Test on different operating systems

### DIFF
--- a/.github/workflows/test-compatibility.yaml
+++ b/.github/workflows/test-compatibility.yaml
@@ -53,6 +53,12 @@ jobs:
     with:
       flake8_matrix: ${{needs.get-versions.outputs.flake8}}
 
+  test-os-versions:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    needs: get-versions
+    with:
+      os_matrix: '["ubuntu-latest", "windows-latest", "macos-latest"]'
 
 
 # either set permissive default permissions in repositories Actions settings or set them explicitly here

--- a/.github/workflows/test-compatibility.yaml
+++ b/.github/workflows/test-compatibility.yaml
@@ -55,11 +55,9 @@ jobs:
 
 
 
-    # either set permissive default permissions in repositories Actions settings or set them explicitly here
-    # permissions:
-    #   checks: write
-    #   issues: read
-    #   pull-requests: write
-    #   contents: read
-
-
+# either set permissive default permissions in repositories Actions settings or set them explicitly here
+permissions:
+  checks: write
+  issues: read
+  pull-requests: write
+  contents: read

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -7,6 +7,8 @@ jobs:
   test-current-version:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
+    with:
+      os_matrix: '["ubuntu-latest", "windows-latest", "macos-latest"]'
 
 # either set permissive default permissions in repositories Actions settings or set them explicitly here
 permissions:

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -8,11 +8,10 @@ jobs:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
 
-    # either set permissive default permissions in repositories Actions settings or set them explicitly here
-    # permissions:
-    #   checks: write
-    #   issues: read
-    #   pull-requests: write
-    #   contents: read
-
+# either set permissive default permissions in repositories Actions settings or set them explicitly here
+permissions:
+  checks: write
+  issues: read
+  pull-requests: write
+  contents: read
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,6 @@
 name: Tests compatibility for several versions
 
+# Note that testing non-default pylint or flake8 version is only supported on Linux.
 
 on:
   workflow_call:
@@ -13,6 +14,9 @@ on:
       flake8_matrix:
         type: string
         default: '["default"]'
+      os_matrix:
+        type: string
+        default: '["ubuntu-latest"]'
     secrets:
       PAT_PRIVATE_TESTS:
         required: true
@@ -20,9 +24,6 @@ on:
 
 jobs:
   pytest:
-    # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-    runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +31,10 @@ jobs:
         python: ${{ fromJSON(inputs.python_matrix) }}
         pylint: ${{ fromJSON(inputs.pylint_matrix) }}
         flake8: ${{ fromJSON(inputs.flake8_matrix) }}
+        os:     ${{ fromJSON(inputs.os_matrix) }}
+
+    # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,6 +64,9 @@ jobs:
       - name: Install Edulint
         run: pip install .
 
+      - name: Log versions of python packages
+        run: pip freeze
+
       - name: Test with pytest
         run: pytest --junit-xml pytest.xml tests/
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,10 +9,10 @@ on:
         default: '["3.8"]'
       pylint_matrix:
         type: string
-        default: '["2.17.5"]'
+        default: '["default"]'
       flake8_matrix:
         type: string
-        default: '["6.1.0"]'
+        default: '["default"]'
     secrets:
       PAT_PRIVATE_TESTS:
         required: true
@@ -26,12 +26,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ${{ fromJSON(inputs.python_matrix) }}
-
         # https://github.com/actions/runner/issues/1660#issuecomment-1359707506
+        python: ${{ fromJSON(inputs.python_matrix) }}
         pylint: ${{ fromJSON(inputs.pylint_matrix) }}
-        # pylint: ${{ fromJSON('["2.16.4", "2.17.4", "3.0.0a6"]') }}
-
         flake8: ${{ fromJSON(inputs.flake8_matrix) }}
 
     steps:
@@ -51,11 +48,13 @@ jobs:
         run: |
           sed -i "s/pylint *[~<>=][^\"]*/pylint==${{ matrix.pylint }}/" requirements.txt
           sed -i "s/pylint *[~<>=][^\"]*/pylint ==${{ matrix.pylint }}/" setup.cfg
+        if: ${{ matrix.pylint != 'default' }}
 
       - name: Mock flake8 version in requirements.txt and setup.cfg
         run: |
           sed -i "s/flake8 *[~<>=][^\"]*/flake8==${{ matrix.flake8 }}/" requirements.txt
           sed -i "s/flake8 *[~<>=][^\"]*/flake8 ==${{ matrix.flake8 }}/" setup.cfg
+        if: ${{ matrix.flake8 != 'default' }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,9 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.dev.txt ]; then pip install -r requirements.dev.txt; fi
-          if [ -f tests/requirements.txt ]; then pip install -r tests/requirements.txt; fi
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -r requirements.dev.txt -r tests/requirements.txt -r requirements.txt
 
       - name: Install Edulint
         run: pip install .


### PR DESCRIPTION
This PR extends existing GitHub actions to perform tests on multiple OS. On every push the tests are executed on ubuntu, windows and macos.

Also, they can be invoked in the [grand compatibility matrix test](https://github.com/GiraffeReversed/edulint/actions/workflows/test-compatibility.yaml). (That one is likely to always fail, as we're also testing unsupported versions, but it's possible to check which versions succeeded and which failed.)

Github doesn't have hosted ARM runners (e.g. for Apple M1/M2), so we're unable to test that. At least not without self hosting a runner on something like Raspberry Pi or ARM VM in cloud.

