### PR TITLE
Add support for installing with pipx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+name = "edulint"
+version = "4.1.3"  # Replace with your actual version
+dynamic = ["readme", "requires-python", "license", "classifiers", "urls", "dependencies"]
+
 [build-system]
 requires = ["setuptools>=62.6"]  # required for: "install_requires = file: requirements.txt"
 build-backend = "setuptools.build_meta"
+
+[project.scripts]
+edulint = "edulint.edulint:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 name = "edulint"
-version = "4.1.3"  # Replace with your actual version
-dynamic = ["readme", "requires-python", "license", "classifiers", "urls", "dependencies"]
+dynamic = ["readme", "requires-python", "license", "classifiers", "dependencies", "version"]
 
 [build-system]
 requires = ["setuptools>=62.6"]  # required for: "install_requires = file: requirements.txt"


### PR DESCRIPTION
Hello,
In this pull request, I have implemented support for installing Edulint using pipx for operating systems with managed pip environments, such as Arch Linux.

Additionally, I have tested the resulting package with both the check and version commands.

Thank you for considering this addition. I look forward to your feedback.
