### PR TITLE
In range instead of compare

### DIFF
--- a/edulint/linting/checkers/local_defects.py
+++ b/edulint/linting/checkers/local_defects.py
@@ -556,8 +556,12 @@ class Local(BaseChecker):
                     return None
 
                 return [
-                    val1 if value == 0 else (val1 + " + " if value > 0 else " - " + str(abs(value)))
-                    for value in range(start_val, stop_val, step)
+                    (
+                        val1
+                        if value == 0
+                        else (val1 + (" + " if value > 0 else " - ") + str(abs(value)))
+                    )
+                    for value in range(const1, const2, step)
                 ]
 
             return None
@@ -655,7 +659,9 @@ class Local(BaseChecker):
     def visit_annassign(self, node: nodes.AnnAssign) -> None:
         self._check_augmentable(node)
 
-    @only_required_for_messages("no-is-bool", "magical-constant-in-ord-compare")
+    @only_required_for_messages(
+        "no-is-bool", "magical-constant-in-ord-compare", "in-range-instead-of-compare-small"
+    )
     def visit_compare(self, node: nodes.Compare) -> None:
         self._check_no_is(node)
         self._check_magical_constant_in_ord_compare(node)

--- a/edulint/linting/checkers/local_defects.py
+++ b/edulint/linting/checkers/local_defects.py
@@ -513,6 +513,12 @@ class Local(BaseChecker):
         def is_var(node: nodes.NodeNG) -> bool:
             return isinstance(node, (nodes.Name, nodes.Call, nodes.Subscript, nodes.Attribute))
 
+        def add_brackets_if_necessary(node: nodes.NodeNG) -> str:
+            if isinstance(node, (nodes.BinOp, nodes.UnaryOp)):
+                return f"({node.as_string()})"
+
+            return node.as_string()
+
         def get_value_plus_constant(node: nodes.NodeNG) -> Optional[Tuple[str, int]]:
             if is_var(node):
                 var = node.as_string()
@@ -673,7 +679,7 @@ class Local(BaseChecker):
                 (
                     str(start_val % abs(step_val))
                     if start_val is not None
-                    else f"{start.as_string()} % {str(step_val)}"
+                    else f"{add_brackets_if_necessary(start)} % {str(abs(step_val))}"
                 ),
             ]
         )

--- a/edulint/linting/checkers/local_defects.py
+++ b/edulint/linting/checkers/local_defects.py
@@ -562,7 +562,11 @@ class Local(BaseChecker):
 
             return None
 
-        if len(node.ops) == 1 and (node.ops[0][0] == "in" or node.ops[0][0] == "not in") and is_var(node.left):
+        if (
+            len(node.ops) == 1
+            and (node.ops[0][0] == "in" or node.ops[0][0] == "not in")
+            and is_var(node.left)
+        ):
             range_params = get_range_params(node.ops[0][1])
             if range_params is None:
                 return
@@ -590,17 +594,23 @@ class Local(BaseChecker):
 
             if all_values is not None:
                 if len(all_values) == 0:
-                    suggested_replacement = 'False' if node.ops[0][0] == "in" else 'True'
+                    suggested_replacement = "False" if node.ops[0][0] == "in" else "True"
                 else:
-                    comparison = f'{node.left.as_string()} {'==' if node.ops[0][0] == "in" else '!='} '
-                    suggested_replacement = comparison + f' {'or' if node.ops[0][0] == "in" else 'and'} {comparison}'.join(all_values)
+                    comparison = (
+                        f'{node.left.as_string()} {"==" if node.ops[0][0] == "in" else "!="} '
+                    )
+                    suggested_replacement = (
+                        comparison
+                        + f' {"or" if node.ops[0][0] == "in" else "and"} {comparison}'.join(
+                            all_values
+                        )
+                    )
 
                 self.add_message(
                     "in-range-instead-of-compare-small",
                     node=node,
                     args=(node.as_string(), suggested_replacement),
                 )
-
 
     @only_required_for_messages("use-append", "use-isdecimal", "use-integral-division")
     def visit_call(self, node: nodes.Call) -> None:

--- a/edulint/linting/checkers/local_defects.py
+++ b/edulint/linting/checkers/local_defects.py
@@ -483,6 +483,15 @@ class Local(BaseChecker):
         ):
             self.add_message("use-early-return", node=node)
 
+    def _check_in_range_instead_of_compare(self, node: nodes.Compare) -> None:
+        if len(node.ops) == 1 and node.ops[0][0] == "in":
+            range_params = get_range_params(node.ops[0][1])
+            if range_params is None:
+                return
+
+            start, stop, step = range_params
+            # start, stop, step = node.value if isinstance(node, nodes.Const) else None
+
     @only_required_for_messages("use-append", "use-isdecimal", "use-integral-division")
     def visit_call(self, node: nodes.Call) -> None:
         self._check_extend(node)
@@ -530,6 +539,7 @@ class Local(BaseChecker):
     def visit_compare(self, node: nodes.Compare) -> None:
         self._check_no_is(node)
         self._check_magical_constant_in_ord_compare(node)
+        self._check_in_range_instead_of_compare(node)
 
 
 def register(linter: "PyLinter") -> None:

--- a/edulint/linting/checkers/local_defects.py
+++ b/edulint/linting/checkers/local_defects.py
@@ -616,6 +616,8 @@ class Local(BaseChecker):
                     args=(node.as_string(), suggested_replacement),
                 )
 
+            # TODO - finish the other cases (not small)
+
     @only_required_for_messages("use-append", "use-isdecimal", "use-integral-division")
     def visit_call(self, node: nodes.Call) -> None:
         self._check_extend(node)

--- a/tests/test_local_defects.py
+++ b/tests/test_local_defects.py
@@ -125,6 +125,48 @@ def test_no_is_custom(lines: List[str], expected_output: List[Problem]) -> None:
         [problem.set_code("R6613") for problem in expected_output]
     )
 
+@pytest.mark.parametrize("lines,expected_output", [
+    ([
+        "x in range(1, 10)",
+        "x in range(1, 10, 2)",
+        "x in range(1, 10, 5)",
+        "x in range(2, 11, 4)",
+        "x not in range(1, 10, 2)",
+        "x in range(3, -10, -2)",
+        "x in range(1)",
+        "x in range(start, start + 2)",
+        "x in range(start + 1, start - 5, -3)",
+        "x in range(start, stop, -3)"
+    ], [
+        lazy_problem().set_line(1)
+        .set_text("Consider replacing 'x in range(1, 10)' with '1 <= x and x < 10'"),
+        lazy_problem().set_line(2)
+        .set_text("Consider replacing 'x in range(1, 10, 2)' with '1 <= x and x < 10 and x % 2 == 1'"),
+        lazy_problem().set_line(3)
+        .set_text("Consider replacing 'x in range(1, 10, 5)' with 'x == 1 or x == 6'"),
+        lazy_problem().set_line(4)
+        .set_text("Consider replacing 'x in range(2, 11, 4)' with 'x == 2 or x == 6 or x == 10'"),
+        lazy_problem().set_line(5)
+        .set_text("Consider replacing 'x not in range(1, 10, 2)' with '1 > x or x >= 10 or x % 2 != 1'"),
+        lazy_problem().set_line(6)
+        .set_text("Consider replacing 'x in range(3, -10, -2)' with '3 >= x and x > -10 and x % 2 == 1'"),
+        lazy_problem().set_line(7)
+        .set_text("Consider replacing 'x in range(1)' with 'x == 0'"),
+        lazy_problem().set_line(8)
+        .set_text("Consider replacing 'x in range(start, start + 2)' with 'x == start or x == start + 1'"),
+        lazy_problem().set_line(9)
+        .set_text("Consider replacing 'x in range(start + 1, start - 5, -3)' with 'x == start + 1 or x == start - 2'"),
+        lazy_problem().set_line(10)
+        .set_text("Consider replacing 'x in range(start, stop, -3)' with 'start >= x and x > stop and x % 3 == start % 3'"),
+    ]),
+])
+def test_redundant_compare_with_variables(lines: List[str], expected_output: List[Problem]) -> None:
+    create_apply_and_lint(
+        lines,
+        [Arg(Option.PYLINT, "--enable=R6617,R6618,R6619")],
+        expected_output,
+    )
+
 @pytest.mark.parametrize("filename,expected_output", [
     ("044050-vigenere.py", [
         lazy_problem().set_code("R6614").set_line(38)

--- a/tests/test_local_defects.py
+++ b/tests/test_local_defects.py
@@ -148,9 +148,9 @@ def test_no_is_custom(lines: List[str], expected_output: List[Problem]) -> None:
         lazy_problem().set_line(5)
         .set_text("Consider replacing 'x in range(2, 11, 4)' with 'x == 2 or x == 6 or x == 10'"),
         lazy_problem().set_line(6)
-        .set_text("Consider replacing 'x not in range(1, 10, 2)' with '1 > x or x >= 10 or x % 2 != 1'"),
+        .set_text("Consider replacing 'x not in range(1, 10, 2)' with 'x < 1 or 10 <= x or x % 2 != 1'"),
         lazy_problem().set_line(7)
-        .set_text("Consider replacing 'x in range(3, -10, -2)' with '3 >= x and x > -10 and x % 2 == 1'"),
+        .set_text("Consider replacing 'x in range(3, -10, -2)' with '-10 < x and x <= 3 and x % 2 == 1'"),
         lazy_problem().set_line(8)
         .set_text("Consider replacing 'x in range(1)' with 'x == 0'"),
         lazy_problem().set_line(9)
@@ -158,7 +158,7 @@ def test_no_is_custom(lines: List[str], expected_output: List[Problem]) -> None:
         lazy_problem().set_line(10)
         .set_text("Consider replacing 'x in range(start + 1, start - 5, -3)' with 'x == start + 1 or x == start - 2'"),
         lazy_problem().set_line(11)
-        .set_text("Consider replacing 'x in range(start, stop, -3)' with 'start >= x and x > stop and x % 3 == start % 3'"),
+        .set_text("Consider replacing 'x in range(start, stop, -3)' with 'stop < x and x <= start and x % 3 == start % 3'"),
     ]),
 ])
 def test_redundant_compare_with_variables(lines: List[str], expected_output: List[Problem]) -> None:

--- a/tests/test_local_defects.py
+++ b/tests/test_local_defects.py
@@ -137,7 +137,8 @@ def test_no_is_custom(lines: List[str], expected_output: List[Problem]) -> None:
         "x in range(1)",
         "x in range(start, start + 2)",
         "x in range(start + 1, start - 5, -3)",
-        "x in range(start, stop, -3)"
+        "x in range(start, stop, -3)",
+        "x not in range(1, -10, -1)",
     ], [
         lazy_problem().set_line(2)
         .set_text("Consider replacing 'x in range(1, 10)' with '1 <= x and x < 10'"),
@@ -159,6 +160,8 @@ def test_no_is_custom(lines: List[str], expected_output: List[Problem]) -> None:
         .set_text("Consider replacing 'x in range(start + 1, start - 5, -3)' with 'x == start + 1 or x == start - 2'"),
         lazy_problem().set_line(11)
         .set_text("Consider replacing 'x in range(start, stop, -3)' with 'stop < x and x <= start and x % 3 == start % 3'"),
+        lazy_problem().set_line(12)
+        .set_text("Consider replacing 'x not in range(1, -10, -1)' with 'x <= -10 or 1 < x'"),
     ]),
 ])
 def test_redundant_compare_with_variables(lines: List[str], expected_output: List[Problem]) -> None:

--- a/tests/test_local_defects.py
+++ b/tests/test_local_defects.py
@@ -127,6 +127,7 @@ def test_no_is_custom(lines: List[str], expected_output: List[Problem]) -> None:
 
 @pytest.mark.parametrize("lines,expected_output", [
     ([
+        "x = 1",
         "x in range(1, 10)",
         "x in range(1, 10, 2)",
         "x in range(1, 10, 5)",
@@ -138,25 +139,25 @@ def test_no_is_custom(lines: List[str], expected_output: List[Problem]) -> None:
         "x in range(start + 1, start - 5, -3)",
         "x in range(start, stop, -3)"
     ], [
-        lazy_problem().set_line(1)
-        .set_text("Consider replacing 'x in range(1, 10)' with '1 <= x and x < 10'"),
         lazy_problem().set_line(2)
-        .set_text("Consider replacing 'x in range(1, 10, 2)' with '1 <= x and x < 10 and x % 2 == 1'"),
+        .set_text("Consider replacing 'x in range(1, 10)' with '1 <= x and x < 10'"),
         lazy_problem().set_line(3)
-        .set_text("Consider replacing 'x in range(1, 10, 5)' with 'x == 1 or x == 6'"),
+        .set_text("Consider replacing 'x in range(1, 10, 2)' with '1 <= x and x < 10 and x % 2 == 1'"),
         lazy_problem().set_line(4)
-        .set_text("Consider replacing 'x in range(2, 11, 4)' with 'x == 2 or x == 6 or x == 10'"),
+        .set_text("Consider replacing 'x in range(1, 10, 5)' with 'x == 1 or x == 6'"),
         lazy_problem().set_line(5)
-        .set_text("Consider replacing 'x not in range(1, 10, 2)' with '1 > x or x >= 10 or x % 2 != 1'"),
+        .set_text("Consider replacing 'x in range(2, 11, 4)' with 'x == 2 or x == 6 or x == 10'"),
         lazy_problem().set_line(6)
-        .set_text("Consider replacing 'x in range(3, -10, -2)' with '3 >= x and x > -10 and x % 2 == 1'"),
+        .set_text("Consider replacing 'x not in range(1, 10, 2)' with '1 > x or x >= 10 or x % 2 != 1'"),
         lazy_problem().set_line(7)
-        .set_text("Consider replacing 'x in range(1)' with 'x == 0'"),
+        .set_text("Consider replacing 'x in range(3, -10, -2)' with '3 >= x and x > -10 and x % 2 == 1'"),
         lazy_problem().set_line(8)
-        .set_text("Consider replacing 'x in range(start, start + 2)' with 'x == start or x == start + 1'"),
+        .set_text("Consider replacing 'x in range(1)' with 'x == 0'"),
         lazy_problem().set_line(9)
-        .set_text("Consider replacing 'x in range(start + 1, start - 5, -3)' with 'x == start + 1 or x == start - 2'"),
+        .set_text("Consider replacing 'x in range(start, start + 2)' with 'x == start or x == start + 1'"),
         lazy_problem().set_line(10)
+        .set_text("Consider replacing 'x in range(start + 1, start - 5, -3)' with 'x == start + 1 or x == start - 2'"),
+        lazy_problem().set_line(11)
         .set_text("Consider replacing 'x in range(start, stop, -3)' with 'start >= x and x > stop and x % 3 == start % 3'"),
     ]),
 ])


### PR DESCRIPTION
This is a PR for the checker that suggests replacing 'x in range(1, 10)' with '1 <= x and x < 10', but also takes care of more complex variations, like: 'x in range(start + 1, start - 5, -3)' with 'x == start + 1 or x == start - 2'.

It would also probably be good to use the guess_type() function here, but that can be added later when it is merged, right now it is not available on this branch.