### PR TITLE
collectively-exhaustive-condition-part

### DIFF
--- a/edulint/linting/checkers/duplication/duplicate_if.py
+++ b/edulint/linting/checkers/duplication/duplicate_if.py
@@ -18,7 +18,7 @@ from edulint.linting.checkers.utils import (
     get_token_count,
     has_else_block,
     is_negation,
-    are_identical,
+    are_same_expression,
     new_node,
 )
 from edulint.linting.checkers.duplication.utils import (
@@ -315,13 +315,13 @@ def restructure_twisted_ifs(tests, inner_if: nodes.If, avars):
 
     # positive and negative branches are twisted
     if not (
-        are_identical(pos_pos, neg_neg)
-        and are_identical(pos_neg, neg_pos)
+        are_same_expression(pos_pos, neg_neg)
+        and are_same_expression(pos_neg, neg_pos)
         and not contains_avar(inner_test, avars)
     ) and not (
         # branches are correctly structured, but the inner condition is negated
-        are_identical(pos_pos, neg_pos)
-        and are_identical(pos_neg, neg_neg)
+        are_same_expression(pos_pos, neg_pos)
+        and are_same_expression(pos_neg, neg_neg)
         and is_negation(
             get_sub_variant(inner_test, 0), get_sub_variant(inner_test, 1), negated_rt=False
         )
@@ -369,13 +369,13 @@ def get_fixed_by_restructuring_twisted(tests, core, avars):
 
     # positive and negative branches are twisted
     if not (
-        are_identical(pos_pos, neg_neg)
-        and are_identical(pos_neg, neg_pos)
+        are_same_expression(pos_pos, neg_neg)
+        and are_same_expression(pos_neg, neg_pos)
         and not contains_avar(inner_test, avars)
     ) and not (
         # branches are correctly structured, but the inner condition is negated
-        are_identical(pos_pos, neg_pos)
-        and are_identical(pos_neg, neg_neg)
+        are_same_expression(pos_pos, neg_pos)
+        and are_same_expression(pos_neg, neg_neg)
         and is_negation(
             get_sub_variant(inner_test, 0), get_sub_variant(inner_test, 1), negated_rt=False
         )

--- a/edulint/linting/checkers/simplifiable_if.py
+++ b/edulint/linting/checkers/simplifiable_if.py
@@ -427,8 +427,6 @@ class SimplifiableIf(BaseChecker):  # type: ignore
             """
             Emitted when a condition like `(A and B) or (A and C) ≡ A and (B or C)` can be simplified to just `A`, because `B or C ≡ True` and similarly when `and`
             and `or` are switched.
-
-            Warning: If you use a variable that can contain float (not an integer) in expression involving %% or // this checker can give incorrect suggestion.
             """,  # in overriders
         ),
     }

--- a/edulint/linting/checkers/utils.py
+++ b/edulint/linting/checkers/utils.py
@@ -689,3 +689,8 @@ def are_identical(
     strings2 = [n.as_string() for n in block2]
 
     return strings1 == strings2
+
+
+def are_same_expression(expr1: nodes.NodeNG, expr2: nodes.NodeNG) -> bool:
+    "Could be improved to take commutativity into account, ie: `x + y` could be considered same as `y + x`."
+    return expr1.as_string() == expr2.as_string()

--- a/edulint/linting/checkers/utils.py
+++ b/edulint/linting/checkers/utils.py
@@ -151,7 +151,6 @@ PURE_FUNCTIONS = {
     "ord",
     "chr",
     "isinstance",
-    "print",
 }
 
 EXPR_FUNCTIONS = PURE_FUNCTIONS | {"all", "any", "map", "filter"}
@@ -258,7 +257,7 @@ def has_more_assign_targets(node: nodes.Assign) -> bool:
 
 
 def get_assign_targets(
-    node: Union[nodes.Assign, nodes.AnnAssign, nodes.AugAssign]
+    node: Union[nodes.Assign, nodes.AnnAssign, nodes.AugAssign],
 ) -> List[nodes.NodeNG]:
     if isinstance(node, nodes.Assign) and isinstance(node.targets[0], nodes.Tuple):
         return list(node.targets[0].get_children())

--- a/edulint/linting/checkers/utils.py
+++ b/edulint/linting/checkers/utils.py
@@ -674,12 +674,13 @@ def is_negation(lt: nodes.NodeNG, rt: nodes.NodeNG, negated_rt: bool) -> bool:
 
 def have_same_value(lt: nodes.NodeNG, rt: nodes.NodeNG):
     # TODO improve, for example not all functions are pure
-    return are_identical(lt, rt)
+    return are_same_expression(lt, rt)
 
 
-def are_identical(
+def are_same_expression(
     block1: Union[nodes.NodeNG, List[nodes.NodeNG]], block2: Union[nodes.NodeNG, List[nodes.NodeNG]]
 ) -> bool:
+    "Could be improved to take commutativity into account, ie: `x + y` could be considered same as `y + x`."
     if isinstance(block1, nodes.NodeNG):
         assert isinstance(block2, nodes.NodeNG)
         block1 = [block1]
@@ -689,8 +690,3 @@ def are_identical(
     strings2 = [n.as_string() for n in block2]
 
     return strings1 == strings2
-
-
-def are_same_expression(expr1: nodes.NodeNG, expr2: nodes.NodeNG) -> bool:
-    "Could be improved to take commutativity into account, ie: `x + y` could be considered same as `y + x`."
-    return expr1.as_string() == expr2.as_string()

--- a/edulint/linting/overrides.py
+++ b/edulint/linting/overrides.py
@@ -26,6 +26,7 @@ OVERRIDERS = {
         "R6212",
         "R6214",
         "R6215",
+        "R6224",
     },  # checkers that might make conflicting or same suggestion as redundant-condition-part
     # R6216=redundant-condition-part, simplifiable-with-abs, redundant-compare-in-condition, using-compare-instead-of-equal, simplifiable-test-by-equals
     "R6213": {"R6216"},
@@ -34,6 +35,7 @@ OVERRIDERS = {
     # R6221=condition-always-false-in-elif, R6222=condition-always-true-or-false
     "R6218": {"R6222"},
     # R6218=condition-always-true-in-elif, R6222=condition-always-true-or-false
+    "R6224": {"R6222"},
 }
 
 

--- a/edulint/linting/overrides.py
+++ b/edulint/linting/overrides.py
@@ -26,7 +26,7 @@ OVERRIDERS = {
         "R6212",
         "R6214",
         "R6215",
-        "R6224",
+        "R6225",
     },  # checkers that might make conflicting or same suggestion as redundant-condition-part
     # R6216=redundant-condition-part, simplifiable-with-abs, redundant-compare-in-condition, using-compare-instead-of-equal, simplifiable-test-by-equals
     "R6213": {"R6216"},
@@ -35,7 +35,7 @@ OVERRIDERS = {
     # R6221=condition-always-false-in-elif, R6222=condition-always-true-or-false
     "R6218": {"R6222"},
     # R6218=condition-always-true-in-elif, R6222=condition-always-true-or-false
-    "R6224": {"R6222"},
+    "R6225": {"R6222"},
 }
 
 

--- a/tests/test_simplifiable_if.py
+++ b/tests/test_simplifiable_if.py
@@ -1122,9 +1122,20 @@ def test_use_if_elif_else_modifying(filename: str, expected_output: List[Problem
         .set_text("'x == y and x % 3 == 0 or x % 3 == 0 and x != y' can be replaced with 'x % 3 == 0'"),
     ]),
 ])
-def test_collectively_exhaustive_condition_part(lines: List[str], expected_output: List[Problem]) -> None:
+def test_collectively_exhaustive_condition_part_custom(lines: List[str], expected_output: List[Problem]) -> None:
     create_apply_and_lint(
         lines,
+        [Arg(Option.PYLINT, "--enable=collectively-exhaustive-condition-part")],
+        expected_output,
+    )
+
+@pytest.mark.parametrize("filename,expected_output", [
+    ("11_chessboard_R6225.py", [lazy_problem().set_line(6)]),
+    ("73_bigchessboard_R6225.py", [lazy_problem().set_line(6)]),
+])
+def test_collectively_exhaustive_condition_part(filename: str, expected_output: List[Problem]) -> None:
+    apply_and_lint(
+        filename,
         [Arg(Option.PYLINT, "--enable=collectively-exhaustive-condition-part")],
         expected_output,
     )

--- a/tests/test_simplifiable_if.py
+++ b/tests/test_simplifiable_if.py
@@ -1102,3 +1102,29 @@ def test_use_if_elif_else_modifying(filename: str, expected_output: List[Problem
         [Arg(Option.PYLINT, "--enable=R6224")],
         expected_output,
     )
+
+@pytest.mark.parametrize("lines,expected_output", [
+    ([
+        "day = 24",
+        "a = 1",
+        "x = 1",
+        "y = 2",
+        "t = (x == y and a % 2 == 0) or (day % 10 == 0 and day % 20 != 0) or x == y or (day % 10 == 0 and day % 20 == 0)",
+        "t = (x == y or a % 2 == 0) and (a % 2 == 0 or x != y)",
+        "t = (x == y or a % 2 == 0) and (a % 2 == 0 or x == 2 * y)",
+        "t = (x == y and x % 3 == 0) or (x % 3 == 1 and x == y) or (x % 3 == 0 and x != y)",
+    ], [
+        lazy_problem().set_line(5)
+        .set_text("'day % 10 == 0 and day % 20 != 0 or day % 10 == 0 and day % 20 == 0' can be replaced with 'day % 10 == 0'"),
+        lazy_problem().set_line(6)
+        .set_text("'(x == y or a % 2 == 0) and (a % 2 == 0 or x != y)' can be replaced with 'a % 2 == 0'"),
+        lazy_problem().set_line(8)
+        .set_text("'x == y and x % 3 == 0 or x % 3 == 0 and x != y' can be replaced with 'x % 3 == 0'"),
+    ]),
+])
+def test_collectively_exhaustive_condition_part(lines: List[str], expected_output: List[Problem]) -> None:
+    create_apply_and_lint(
+        lines,
+        [Arg(Option.PYLINT, "--enable=collectively-exhaustive-condition-part")],
+        expected_output,
+    )


### PR DESCRIPTION
This checker should also be done. It does not detect the example from our defect table: `(day % a == 0 and day % b != 0) or (day % a == 0 and day % b == 0)`, because the `guess_type()` function cannot yet tell the type of `day % a`.

Also it only found two examples in the whole umime_classic and when I turned off the type checking with `guess_type()` ( commented it out from initialize_variables() function), then it found additional 2 examples, where both of them should start being detected when `guess_type()` starts guessing type of `m % n`.

I tried to make it such that if there is something like: `(A and B) or (C and A) or (B and D)`, where `B or C != True`, but `A or D ≡ True`, then it would suggest that `(A and B) or (B and D)` can be replaced with `B`. (ie. even when they are not necessarily next to each other - of course I first check for purity).

I have also added and used function `are_same_expression(expr1, expr2)` into `utils.py` with a simple implementation, by just comparing their `.as_string()`. I guess that you would use this function for the `duplicate condition part` checker when you will be implementing it, but you might enhance it by also dealing with commutativity, ...